### PR TITLE
Remove plugins repo from the README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -22,8 +22,7 @@ The Flutter project has a number of repositories, some important ones include:
 * [engine](https://github.com/flutter/engine): the rendering backend, which is ported to each platform we support.
 * [flutter](https://github.com/flutter/flutter): the Flutter framework and `flutter` command line tool. Start here.
 * [flutter-intellij](https://github.com/flutter/flutter-intellij): the IntelliJ plugin for Flutter.
-* [packages](https://github.com/flutter/packages): the Dart packages maintained by the Flutter team, such as [animations](https://pub.dev/packages/animations) and [rfw](https://pub.dev/packages/rfw).
-* [plugins](https://github.com/flutter/plugins): the Flutter plugins maintained by the Flutter team, such as [camera](https://pub.dev/packages/camera) and [webview_flutter](https://pub.dev/packages/webview_flutter).
+* [packages](https://github.com/flutter/packages): the Dart packages maintained by the Flutter team, such as [animations](https://pub.dev/packages/animations), [rfw](https://pub.dev/packages/rfw), [camera](https://pub.dev/packages/camera), and [webview_flutter](https://pub.dev/packages/webview_flutter).
 * [samples](https://github.com/flutter/samples): examples of Flutter applications for your enjoyment and edification.
 * [tests](https://github.com/flutter/tests): a repository for you to submit your application's tests to ensure that breaking changes don't affect your application.
 * [website](https://github.com/flutter/website): the source for our documentation site, https://docs.flutter.dev/.


### PR DESCRIPTION
Consolidates the plugins content into the "packages" repo entry.

Fixes https://github.com/flutter/flutter/issues/121677