### PR TITLE
[monorepo] Update README reference to engine repository

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -19,10 +19,11 @@ The Flutter project has a number of repositories, some important ones include:
 
 <!-- alphabetical -->
 * [devtools](https://github.com/flutter/devtools): the DevTools tooling (performance tools, inspector, debugger).
-* [engine](https://github.com/flutter/engine): the rendering backend, which is ported to each platform we support.
-* [flutter](https://github.com/flutter/flutter): the Flutter framework and `flutter` command line tool. Start here.
+* [flutter](https://github.com/flutter/flutter): the Flutter framework, engine, and `flutter` command line tool. Start here.
 * [flutter-intellij](https://github.com/flutter/flutter-intellij): the IntelliJ plugin for Flutter.
 * [packages](https://github.com/flutter/packages): the Dart packages maintained by the Flutter team, such as [animations](https://pub.dev/packages/animations), [rfw](https://pub.dev/packages/rfw), [camera](https://pub.dev/packages/camera), and [webview_flutter](https://pub.dev/packages/webview_flutter).
 * [samples](https://github.com/flutter/samples): examples of Flutter applications for your enjoyment and edification.
 * [tests](https://github.com/flutter/tests): a repository for you to submit your application's tests to ensure that breaking changes don't affect your application.
 * [website](https://github.com/flutter/website): the source for our documentation site, https://docs.flutter.dev/.
+
+The Flutter engine was previously located at [flutter/engine](https://github.com/flutter/engine), but has since been merged into [flutter/flutter](https://github.com/flutter/flutter) at the [engine/ directory](https://github.com/flutter/flutter/tree/master/engine). The engine is the rendering backend, which is ported to each platform we support.


### PR DESCRIPTION
A quick update to the profile README given the move to a monorepo. As brought up [on Discord](https://discord.com/channels/608014603317936148/608021234516754444/1329795873475002388).