### PR TITLE
turned on base commit expiration validation and set to 14 days

### DIFF
--- a/autosubmit/autosubmit.yml
+++ b/autosubmit/autosubmit.yml
@@ -21,4 +21,4 @@ run_ci: true
 support_no_review_revert: true
 required_checkruns_on_revert:
   - "ci.yaml validation"
-
+base_commit_allowed_days: 14


### PR DESCRIPTION
turned on base commit expiration validation and set to 14 days

Issue: [170476](https://github.com/flutter/flutter/issues/170476)
