### PR TITLE
Turn On PR base expiration validation for 7 days

### DIFF
--- a/autosubmit/autosubmit.yml
+++ b/autosubmit/autosubmit.yml
@@ -21,4 +21,4 @@ run_ci: true
 support_no_review_revert: true
 required_checkruns_on_revert:
   - "ci.yaml validation"
-base_commit_allowed_days: 0
+base_commit_allowed_days: 7


### PR DESCRIPTION
Turn On PR base expiration validation feature and set it for 7 days

Issue: [170476](https://github.com/flutter/flutter/issues/170476)