### PR TITLE
Add core-packages to the main repo list

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -21,7 +21,7 @@ The Flutter project has a number of repositories, some important ones include:
 * [devtools](https://github.com/flutter/devtools): the DevTools tooling (performance tools, inspector, debugger).
 * [flutter](https://github.com/flutter/flutter): the Flutter framework, engine, and `flutter` command line tool. Start here.
 * [flutter-intellij](https://github.com/flutter/flutter-intellij): the IntelliJ plugin for Flutter.
-* [packages](https://github.com/flutter/packages): the Dart packages maintained by the Flutter team, such as [animations](https://pub.dev/packages/animations), [rfw](https://pub.dev/packages/rfw), [camera](https://pub.dev/packages/camera), and [webview_flutter](https://pub.dev/packages/webview_flutter).
+* [packages](https://github.com/flutter/packages) and [core-packages](https://github.com/flutter/core-packages): the Dart packages maintained by the Flutter team, such as [animations](https://pub.dev/packages/animations), [rfw](https://pub.dev/packages/rfw), [camera](https://pub.dev/packages/camera), and [webview_flutter](https://pub.dev/packages/webview_flutter).
 * [samples](https://github.com/flutter/samples): examples of Flutter applications for your enjoyment and edification.
 * [tests](https://github.com/flutter/tests): a repository for you to submit your application's tests to ensure that breaking changes don't affect your application.
 * [website](https://github.com/flutter/website): the source for our documentation site, https://docs.flutter.dev/.


### PR DESCRIPTION
Adds a link to core-packages in the list of important repos. Rather than try to explain the difference between the two in this short format, I just added it to the existing list item. (The repo READMEs explain the difference if people click through.)